### PR TITLE
Remove argument choice to use with custom GUI

### DIFF
--- a/pyblish_photoshop/cli.py
+++ b/pyblish_photoshop/cli.py
@@ -17,7 +17,6 @@ def cli():
 @cli.command("gui", help='Show Pyblish GUI, Default is to use '
                          '"pyblish_lite".')
 @click.option("package", "--register-gui",
-              type=click.Choice(["pyblish_qml", "pyblish_lite"]),
               default="pyblish_lite")
 def pyblish_gui(package):
     pyblish.api.register_gui(package)

--- a/pyblish_photoshop/version.py
+++ b/pyblish_photoshop/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 0
 VERSION_MINOR = 1
-VERSION_PATCH = 0
+VERSION_PATCH = 1
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
This option throws an exception when I use neither of "pyblish_qml" or "pyblish_lite". Since I use custom pyblish GUI the fastest solution was to remove this line and move forward